### PR TITLE
Taking turns now implemented. Based on a single shot being made

### DIFF
--- a/public/entities/worm.js
+++ b/public/entities/worm.js
@@ -40,7 +40,7 @@ class Worm {
   moveLimit = 5;
   moveCount = 0;
 
-  keyPressed() {
+  keyPressed(wormChoice) {
     if (moveCount >= moveLimit) {
       return;
     }
@@ -48,37 +48,18 @@ class Worm {
     switch(keyCode) {
   
       case LEFT_ARROW: 
-        Matter.Body.applyForce(worm.body, worm.body.position, { x: -0.1, y:0 })
+        Matter.Body.applyForce(wormChoice.body, wormChoice.body.position, { x: -0.1, y:0 })
         moveCount += 1;
         break;
       case RIGHT_ARROW: 
-        Matter.Body.applyForce(worm.body, worm.body.position, { x: 0.1, y:0 })
+        Matter.Body.applyForce(wormChoice.body, wormChoice.body.position, { x: 0.1, y:0 })
         this.body.mass = 10
         moveCount += 1;
         break;
       case UP_ARROW:
-        Matter.Body.applyForce(worm.body, worm.body.position, { x: 0, y:-0.2 })
+        Matter.Body.applyForce(wormChoice.body, wormChoice.body.position, { x: 0, y:-0.2 })
         this.body.mass = 10
         moveCount += 1;
-        break;
-    }
-    return false;
-  }
-
-  // for second worm - temporary? - might be deleted later - when worms take turns
-  keyPressed2() { 
-    switch(keyCode) {
-  
-      case 83: 
-        Matter.Body.applyForce(worm2.body, worm2.body.position, { x: -0.1, y:0 })
-        break;
-      case 68: 
-        Matter.Body.applyForce(worm2.body, worm2.body.position, { x: 0.1, y:0 })
-        this.body.mass = 10
-        break;
-      case 69:
-        Matter.Body.applyForce(worm2.body, worm2.body.position, { x: 0, y:-0.2 })
-        this.body.mass = 10
         break;
     }
     return false;

--- a/public/sketch.js
+++ b/public/sketch.js
@@ -68,6 +68,7 @@ function mouseClicked() {
 
   bulletsWormOne.push(bullet);
   Matter.Body.setVelocity(bullet.body,{x:(-cos(angleDeg))*30, y:-(sin(angleDeg))*30})
+  
   player1Turn = !player1Turn;
   moveCount = 0;
 }

--- a/public/sketch.js
+++ b/public/sketch.js
@@ -10,6 +10,7 @@ let wormImg0;
 let wormImg1;
 let bulletsWormOne;
 let p1;
+let player1Turn;
 
 function preload()
 {
@@ -30,13 +31,14 @@ function setup() {
 
   // ground = Bodies.rectangle(0, windowHeight - 180, 10000, 80, {isStatic: true})
   Matter.World.add(world, ground)
-  console.log(ground)
+  // console.log(ground)
 
   worm = new Worm(150, 0);
   worm2 = new Worm(850, 0, 70, 70, wormImg1);
-  console.log(worm)
+  // console.log(worm)
   // Matter.Body.setMass(worm, 25)
   // worm2 = loadImage('worm2.png');
+  player1Turn = true;
 }
 
 document.addEventListener("mousemove", function(e) {
@@ -59,6 +61,8 @@ function mouseClicked() {
   bullet = new Bullet(worm.body.position.x, worm.body.position.y, 15)
   bulletsWormOne.push(bullet);
   Matter.Body.setVelocity(bullet.body,{x:(-cos(angleDeg))*30, y:-(sin(angleDeg))*30})
+  player1Turn = !player1Turn;
+  moveCount = 0;
 }
 
 function draw() {
@@ -77,26 +81,11 @@ const moveLimit = 5;
 let moveCount = 0;
 
 function keyPressed() {
-//   if (keyCode == RIGHT_ARROW) {
-//     Matter.Body.applyForce(worm.body, worm.body.position, { x: 0.5, y:0 })
-//     console.log("worm position")
-//     console.log(worm.body.position)
-//   }
-//   else if (keyCode == DOWN_ARROW) {
-//     worm.body.y += 10;
-//   }
-//   else if (keyCode == LEFT_ARROW) {
-//     worm.x -= 10;
-//   }
-//   else if (keyCode == UP_ARROW) {
-//     worm.y -= 30;
-//   }
-//   else if (key == ' ') {
-//     worm.setSpeed(0, 0);
-//   }
-//   return false;
-// }
-  worm.keyPressed();
-  worm2.keyPressed2();
+  if(player1Turn === true) {
+    worm.keyPressed(worm);
+  } 
+  else {
+    worm2.keyPressed(worm2);
+  }
 };
 

--- a/public/sketch.js
+++ b/public/sketch.js
@@ -55,10 +55,17 @@ let p2 = {
 
 function mouseClicked() {
 
-  p2 = {x: worm.body.position.x, y: worm.body.position.y }
-   angleDeg = Math.atan2(p2.y - p1.y, p2.x - p1.x);
+  if(player1Turn === true) {
+    p2 = {x: worm.body.position.x, y: worm.body.position.y }
+    angleDeg = Math.atan2(p2.y - p1.y, p2.x - p1.x);
+    bullet = new Bullet(worm.body.position.x, worm.body.position.y, 15)
+  }
+  else {
+    p2 = {x: worm2.body.position.x, y: worm2.body.position.y }
+    angleDeg = Math.atan2(p2.y - p1.y, p2.x - p1.x);
+    bullet = new Bullet(worm2.body.position.x, worm2.body.position.y, 15)
+  }
 
-  bullet = new Bullet(worm.body.position.x, worm.body.position.y, 15)
   bulletsWormOne.push(bullet);
   Matter.Body.setVelocity(bullet.body,{x:(-cos(angleDeg))*30, y:-(sin(angleDeg))*30})
   player1Turn = !player1Turn;


### PR DESCRIPTION
- Changes turns after each shot
- Worms limited to 5 moves each, uses the same keyboard arrows regardless of worm. This is consolidated into a single method whereas it was 2 before (one for each worm which wasnt very DRY)
- Bullet comes from the right worm and at the correct angle.