### PR TITLE
setTimeout now used for change player turn after shooting.

### DIFF
--- a/public/bundle.js
+++ b/public/bundle.js
@@ -72738,7 +72738,9 @@ geometric ideas.`,
           game.bullets.push(this.bullet);
           sound.play();
           Matter.Body.setVelocity(this.bullet.body, { x: -p.cos(angleDeg) * this.bullet.velocity, y: -p.sin(angleDeg) * this.bullet.velocity });
-          game.changePlayerTurn();
+          setTimeout(function() {
+            game.changePlayerTurn();
+          }, 1e3);
           game.timer.resetTimer();
         }
       };

--- a/public/controllers/shootingController.js
+++ b/public/controllers/shootingController.js
@@ -18,7 +18,7 @@ class ShootingController {
 
     sound.play(); 
     Matter.Body.setVelocity(this.bullet.body,{x:(-p.cos(angleDeg))*this.bullet.velocity, y:-(p.sin(angleDeg))*this.bullet.velocity});
-    game.changePlayerTurn();
+    setTimeout(function(){game.changePlayerTurn();},1000)
     game.timer.resetTimer();
   }
 


### PR DESCRIPTION
This solves the issue of a pause between player turns. 