### PR TITLE
timer Navbar fix

### DIFF
--- a/public/controllers/screenController.js
+++ b/public/controllers/screenController.js
@@ -69,6 +69,8 @@ class ScreenController{
       ScreenController.gameScreen(p, game, imgs[1]);
     }
     else if (game.mode === 'gameOver'){
+      game.timer.resetTimer();
+      game.timer.clearTimer();
       ScreenController.gameOverScreen(p, imgs[2], game);
     }
     else if (game.mode === 'instructions') {

--- a/public/views/navbar.js
+++ b/public/views/navbar.js
@@ -31,7 +31,11 @@ class Navbar {
   static showTimer(game) {
     let timeLeft = document.getElementById("timeLeft");
     timeLeft.innerText = game.timer.timeLeftOnTurn();
-    if (game.timer.timeLeftOnTurn() <= 5) { 
+    if(game.timer.timeLeftOnTurn() <= 0) {
+      game.changePlayerTurn();
+      game.timer.resetTimer();
+    }
+    else if (game.timer.timeLeftOnTurn() <= 5) { 
       timeLeft.classList.remove("blackText");
       timeLeft.classList.add("redText");
      } else {


### PR DESCRIPTION
- Navbar now checks if timer reaches 0, changes the turn and resets the timer. 
- GameOver screen stops the timer running and resets it. Previously it just kept running after a game ended